### PR TITLE
[Bug] 계산기 결과 화면 넘어갈 때 MissingFieldException 발생

### DIFF
--- a/core/navigation/src/main/java/com/hongstudio/core/navigation/CustomNavType.kt
+++ b/core/navigation/src/main/java/com/hongstudio/core/navigation/CustomNavType.kt
@@ -2,7 +2,6 @@ package com.hongstudio.core.navigation
 
 import android.os.Bundle
 import androidx.navigation.NavType
-import com.hongstudio.core.model.CalculatorData
 import com.hongstudio.core.model.CalculatorSelected
 import kotlinx.serialization.json.Json
 
@@ -28,30 +27,5 @@ val CalculatorSelectedNavType = object : NavType<CalculatorSelected>(isNullableA
 
     override fun serializeAsValue(value: CalculatorSelected): String {
         return Json.encodeToString(CalculatorSelected.serializer(), value)
-    }
-}
-
-val CalculatorDataNavType = object : NavType<CalculatorData>(isNullableAllowed = false) {
-    override fun get(
-        bundle: Bundle,
-        key: String
-    ): CalculatorData? {
-        return bundle.getString(key)?.let { Json.decodeFromString(it) }
-    }
-
-    override fun parseValue(value: String): CalculatorData {
-        return Json.decodeFromString(value)
-    }
-
-    override fun put(
-        bundle: Bundle,
-        key: String,
-        value: CalculatorData
-    ) {
-        bundle.putString(key, Json.encodeToString(CalculatorData.serializer(), value))
-    }
-
-    override fun serializeAsValue(value: CalculatorData): String {
-        return Json.encodeToString(CalculatorData.serializer(), value)
     }
 }

--- a/core/navigation/src/main/java/com/hongstudio/core/navigation/TypeMap.kt
+++ b/core/navigation/src/main/java/com/hongstudio/core/navigation/TypeMap.kt
@@ -1,0 +1,35 @@
+package com.hongstudio.core.navigation
+
+import android.os.Bundle
+import androidx.navigation.NavType
+import com.hongstudio.core.model.CalculatorData
+import kotlinx.serialization.json.Json
+import kotlin.reflect.typeOf
+
+val calculatorDataTypeMap = mapOf(
+    typeOf<CalculatorData>() to object : NavType<CalculatorData>(isNullableAllowed = false) {
+        override fun get(
+            bundle: Bundle,
+            key: String
+        ): CalculatorData? {
+            return bundle.getString(key)?.let { Json.decodeFromString(it) }
+        }
+
+        override fun parseValue(value: String): CalculatorData {
+            return Json.decodeFromString(value)
+        }
+
+        override fun put(
+            bundle: Bundle,
+            key: String,
+            value: CalculatorData
+        ) {
+            bundle.putString(key, Json.encodeToString(CalculatorData.serializer(), value))
+        }
+
+        override fun serializeAsValue(value: CalculatorData): String {
+            return Json.encodeToString(CalculatorData.serializer(), value)
+        }
+    }
+)
+

--- a/feature/calculator/src/main/java/com/hongstudio/feature/calculator/CalculatorResultScreen.kt
+++ b/feature/calculator/src/main/java/com/hongstudio/feature/calculator/CalculatorResultScreen.kt
@@ -7,35 +7,32 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.hongstudio.core.model.CalculatorData
-import java.util.Locale
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.hongstudio.feature.calculator.model.CalculatorResultUiState
 
 @Composable
 internal fun CalculatorResultRoute(
     padding: PaddingValues,
-    calculatorData: CalculatorData
+    viewModel: CalculatorResultViewModel = hiltViewModel()
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
     CalculatorResultScreen(
         padding = padding,
-        calculatorData = calculatorData
+        uiState = uiState
     )
 }
 
 @Composable
-internal fun CalculatorResultScreen(
+private fun CalculatorResultScreen(
     padding: PaddingValues,
-    calculatorData: CalculatorData
+    uiState: CalculatorResultUiState
 ) {
-    val (electricity, gas, water, trash) = calculatorData
-    val total = String.format(
-        Locale.getDefault(),
-        "%,.1f",
-        electricity * 0.4781 + gas * 2.176 + water * 0.237 + trash * 0.9529
-    )
-
     Column(
         modifier = Modifier
             .padding(padding)
@@ -44,7 +41,7 @@ internal fun CalculatorResultScreen(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text("총 CO₂ 발생량")
-        Text("$total kg/월")
+        Text("${uiState.total} kg/월")
     }
 }
 
@@ -53,6 +50,6 @@ internal fun CalculatorResultScreen(
 private fun CalculatorResultScreenPreview() {
     CalculatorResultScreen(
         padding = PaddingValues(),
-        calculatorData = CalculatorData(0.0, 0.0, 0.0, 0.0)
+        uiState = CalculatorResultUiState()
     )
 }

--- a/feature/calculator/src/main/java/com/hongstudio/feature/calculator/CalculatorResultViewModel.kt
+++ b/feature/calculator/src/main/java/com/hongstudio/feature/calculator/CalculatorResultViewModel.kt
@@ -3,7 +3,7 @@ package com.hongstudio.feature.calculator
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.toRoute
-import com.hongstudio.core.model.CalculatorData
+import com.hongstudio.core.navigation.Route
 import com.hongstudio.core.navigation.calculatorDataTypeMap
 import com.hongstudio.feature.calculator.model.CalculatorResultUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -21,7 +21,8 @@ class CalculatorResultViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(CalculatorResultUiState())
     val uiState: StateFlow<CalculatorResultUiState> = _uiState.asStateFlow()
 
-    private val calculatorData = savedStateHandle.toRoute<CalculatorData>(calculatorDataTypeMap)
+    private val calculatorData =
+        savedStateHandle.toRoute<Route.CalculatorResult>(calculatorDataTypeMap).calculatorData
 
     init {
         val (electricity, gas, water, trash) = calculatorData

--- a/feature/calculator/src/main/java/com/hongstudio/feature/calculator/CalculatorResultViewModel.kt
+++ b/feature/calculator/src/main/java/com/hongstudio/feature/calculator/CalculatorResultViewModel.kt
@@ -1,0 +1,36 @@
+package com.hongstudio.feature.calculator
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
+import com.hongstudio.core.model.CalculatorData
+import com.hongstudio.core.navigation.calculatorDataTypeMap
+import com.hongstudio.feature.calculator.model.CalculatorResultUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.Locale
+import javax.inject.Inject
+
+@HiltViewModel
+class CalculatorResultViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CalculatorResultUiState())
+    val uiState: StateFlow<CalculatorResultUiState> = _uiState.asStateFlow()
+
+    private val calculatorData = savedStateHandle.toRoute<CalculatorData>(calculatorDataTypeMap)
+
+    init {
+        val (electricity, gas, water, trash) = calculatorData
+        val total = String.format(
+            Locale.getDefault(),
+            "%,.1f",
+            electricity * 0.4781 + gas * 2.176 + water * 0.237 + trash * 0.9529
+        )
+
+        _uiState.value = _uiState.value.copy(total = total)
+    }
+}

--- a/feature/calculator/src/main/java/com/hongstudio/feature/calculator/model/CalculatorResultUiState.kt
+++ b/feature/calculator/src/main/java/com/hongstudio/feature/calculator/model/CalculatorResultUiState.kt
@@ -1,0 +1,5 @@
+package com.hongstudio.feature.calculator.model
+
+data class CalculatorResultUiState(
+    val total: String = ""
+)

--- a/feature/calculator/src/main/java/com/hongstudio/feature/calculator/navigation/CalculatorNavigation.kt
+++ b/feature/calculator/src/main/java/com/hongstudio/feature/calculator/navigation/CalculatorNavigation.kt
@@ -7,10 +7,10 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.hongstudio.core.model.CalculatorData
 import com.hongstudio.core.model.CalculatorSelected
-import com.hongstudio.core.navigation.CalculatorDataNavType
 import com.hongstudio.core.navigation.CalculatorSelectedNavType
 import com.hongstudio.core.navigation.MainTabRoute
 import com.hongstudio.core.navigation.Route
+import com.hongstudio.core.navigation.calculatorDataTypeMap
 import com.hongstudio.feature.calculator.CalculatorInstructionRoute
 import com.hongstudio.feature.calculator.CalculatorResultRoute
 import com.hongstudio.feature.calculator.CalculatorRoute
@@ -48,12 +48,8 @@ fun NavGraphBuilder.calculatorNavGraph(
     }
 
     composable<Route.CalculatorResult>(
-        typeMap = mapOf(typeOf<CalculatorData>() to CalculatorDataNavType)
-    ) { navBackStackEntry ->
-        val calculatorData = navBackStackEntry.toRoute<Route.CalculatorResult>().calculatorData
-        CalculatorResultRoute(
-            padding = padding,
-            calculatorData = calculatorData
-        )
+        typeMap = calculatorDataTypeMap
+    ) {
+        CalculatorResultRoute(padding = padding)
     }
 }


### PR DESCRIPTION
[블로그](https://velog.io/@mraz3068/Android-Compose-Type-Safe-Navigation-Custom-Data-Class-Argument-Delivery-Way)와 [샘플 코드](https://github.com/easyhooon/NavigationCustomDataClassArgumentExample)를 참고하여 따라했는데 어느 부분이 문제이길래 MissingFieldException이 발생하는지 모르겠습니다. 계산기 화면에서 계산결과 화면으로 넘어갈 때 해당 오류가 발생합니다.

* #5 

``` E  FATAL EXCEPTION: main
    Process: com.hongstudio.carboncalculator, PID: 14107
    kotlinx.serialization.MissingFieldException: Fields [electricity, gas, water, trash] are required for type with serial name 'com.hongstudio.core.model.CalculatorData', but they were missing
    	at kotlinx.serialization.internal.PluginExceptionsKt.throwMissingFieldException(PluginExceptions.kt:20)
    	at com.hongstudio.core.model.CalculatorData.<init>(CalculatorData.kt:5)
    	at com.hongstudio.core.model.CalculatorData$$serializer.deserialize(CalculatorData.kt:5)
    	at com.hongstudio.core.model.CalculatorData$$serializer.deserialize(CalculatorData.kt:5)
    	at kotlinx.serialization.encoding.Decoder$DefaultImpls.decodeSerializableValue(Decoding.kt:257)
    	at kotlinx.serialization.encoding.AbstractDecoder.decodeSerializableValue(AbstractDecoder.kt:16)
    	at androidx.navigation.serialization.RouteDecoder.decodeRouteWithArgs$navigation_common_release(RouteDecoder.kt:96)
    	at androidx.navigation.serialization.RouteDeserializerKt.decodeArguments(RouteDeserializer.kt:35)
    	at androidx.navigation.SavedStateHandleKt.internalToRoute(SavedStateHandle.kt:51)
    	at com.hongstudio.feature.calculator.CalculatorResultViewModel.<init>(CalculatorResultViewModel.kt:37)
    	at com.hongstudio.carboncalculator.DaggerCarbonCalculatorApplication_HiltComponents_SingletonC$ViewModelCImpl$SwitchingProvider.get(DaggerCarbonCalculatorApplication_HiltComponents_SingletonC.java:504)
    	at dagger.hilt.android.internal.lifecycle.HiltViewModelFactory$2.createViewModel(HiltViewModelFactory.java:132)
    	at dagger.hilt.android.internal.lifecycle.HiltViewModelFactory$2.create(HiltViewModelFactory.java:103)
    	at dagger.hilt.android.internal.lifecycle.HiltViewModelFactory.create(HiltViewModelFactory.java:170)
    	at androidx.lifecycle.ViewModelProvider$Factory.create(ViewModelProvider.android.kt:158)
    	at androidx.lifecycle.viewmodel.ViewModelProviderImpl_androidKt.createViewModel(ViewModelProviderImpl.android.kt:34)
    	at androidx.lifecycle.viewmodel.ViewModelProviderImpl.getViewModel$lifecycle_viewmodel_release(ViewModelProviderImpl.kt:65)
    	at androidx.lifecycle.viewmodel.ViewModelProviderImpl.getViewModel$lifecycle_viewmodel_release$default(ViewModelProviderImpl.kt:47)
    	at androidx.lifecycle.ViewModelProvider.get(ViewModelProvider.android.kt:91)
    	at androidx.lifecycle.viewmodel.compose.ViewModelKt__ViewModelKt.get(ViewModel.kt:162)
    	at androidx.lifecycle.viewmodel.compose.ViewModelKt.get(Unknown Source:1)
    	at androidx.lifecycle.viewmodel.compose.ViewModelKt__ViewModel_androidKt.viewModel(ViewModel.android.kt:124)
    	at androidx.lifecycle.viewmodel.compose.ViewModelKt.viewModel(Unknown Source:1)
    	at com.hongstudio.feature.calculator.CalculatorResultScreenKt.CalculatorResultRoute(CalculatorResultScreen.kt:68)
    	at com.hongstudio.feature.calculator.navigation.CalculatorNavigationKt$calculatorNavGraph$3.invoke(CalculatorNavigation.kt:53)
    	at com.hongstudio.feature.calculator.navigation.CalculatorNavigationKt$calculatorNavGraph$3.invoke(CalculatorNavigation.kt:52)
    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:139)
    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
    	at androidx.navigation.compose.NavHostKt$NavHost$32$1.invoke(NavHost.kt:694)
    	at androidx.navigation.compose.NavHostKt$NavHost$32$1.invoke(NavHost.kt:693)
    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:109)
    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
    	at androidx.compose.runtime.CompositionLocalKt.CompositionLocalProvider(CompositionLocal.kt:401)
    	at androidx.compose.runtime.saveable.SaveableStateHolderImpl.SaveableStateProvider(SaveableStateHolder.kt:85)
    	at androidx.navigation.compose.NavBackStackEntryProviderKt.SaveableStateProvider(NavBackStackEntryProvider.kt:65)
    	at androidx.navigation.compose.NavBackStackEntryProviderKt.access$SaveableStateProvider(NavBackStackEntryProvider.kt:1)
 E  	at androidx.navigation.compose.NavBackStackEntryProviderKt$LocalOwnersProvider$1.invoke(NavBackStackEntryProvider.kt:52)
    	at androidx.navigation.compose.NavBackStackEntryProviderKt$LocalOwnersProvider$1.invoke(NavBackStackEntryProvider.kt:51)
    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:109)
    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
    	at androidx.compose.runtime.CompositionLocalKt.CompositionLocalProvider(CompositionLocal.kt:380)
    	at androidx.navigation.compose.NavBackStackEntryProviderKt.LocalOwnersProvider(NavBackStackEntryProvider.kt:47)
    	at androidx.navigation.compose.NavHostKt$NavHost$32.invoke(NavHost.kt:693)
    	at androidx.navigation.compose.NavHostKt$NavHost$32.invoke(NavHost.kt:674)
    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:139)
    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
    	at androidx.compose.animation.AnimatedContentKt$AnimatedContent$6$1$5.invoke(AnimatedContent.kt:803)
    	at androidx.compose.animation.AnimatedContentKt$AnimatedContent$6$1$5.invoke(AnimatedContent.kt:792)
    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:118)
    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
    	at androidx.compose.animation.AnimatedVisibilityKt.AnimatedEnterExitImpl(AnimatedVisibility.kt:771)
    	at androidx.compose.animation.AnimatedContentKt$AnimatedContent$6$1.invoke(AnimatedContent.kt:774)
    	at androidx.compose.animation.AnimatedContentKt$AnimatedContent$6$1.invoke(AnimatedContent.kt:757)
    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:109)
    	at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
    	at androidx.compose.animation.AnimatedContentKt.AnimatedContent(AnimatedContent.kt:816)
    	at androidx.navigation.compose.NavHostKt.NavHost(NavHost.kt:646)
    	at androidx.navigation.compose.NavHostKt$NavHost$34.invoke(Unknown Source:29)
    	at androidx.navigation.compose.NavHostKt$NavHost$34.invoke(Unknown Source:10)
    	at androidx.compose.runtime.RecomposeScopeImpl.compose(RecomposeScopeImpl.kt:192)
    	at androidx.compose.runtime.ComposerImpl.recomposeToGroupEnd(Composer.kt:2825)
    	at androidx.compose.runtime.ComposerImpl.skipCurrentGroup(Composer.kt:3116)
    	at androidx.compose.runtime.ComposerImpl.doCompose(Composer.kt:3607)
    	at androidx.compose.runtime.ComposerImpl.recompose$runtime_release(Composer.kt:3552)
    	at androidx.compose.runtime.CompositionImpl.recompose(Composition.kt:948)
    	at androidx.compose.runtime.Recomposer.performRecompose(Recomposer.kt:1206)
    	at androidx.compose.runtime.Recomposer.access$performRecompose(Recomposer.kt:132)
    	at androidx.compose.runtime.Recomposer$runRecomposeAndApplyChanges$2$1.invoke(Recomposer.kt:616)
    	at androidx.compose.runtime.Recomposer$runRecomposeAndApplyChanges$2$1.invoke(Recomposer.kt:585)
    	at androidx.compose.ui.platform.AndroidUiFrameClock$withFrameNanos$2$callback$1.doFrame(AndroidUiFrameClock.android.kt:41)
    	at androidx.compose.ui.platform.AndroidUiDispatcher.performFrameDispatch(AndroidUiDispatcher.android.kt:109)
    	at androidx.compose.ui.platform.AndroidUiDispatcher.access$performFrameDispatch(AndroidUiDispatcher.android.kt:41)
    	at androidx.compose.ui.platform.AndroidUiDispatcher$dispatchCallback$1.doFrame(AndroidUiDispatcher.android.kt:69)
    	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1299)
    	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1309)
    	at android.view.Choreographer.doCallbacks(Choreographer.java:923)
    	at android.view.Choreographer.doFrame(Choreographer.java:847)
    	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1283)
    	at android.os.Handler.handleCallback(Handler.java:942)
    	at android.os.Handler.dispatchMessage(Handler.java:99)
    	at android.os.Looper.loopOnce(Looper.java:226)
 E  	at android.os.Looper.loop(Looper.java:313)
    	at android.app.ActivityThread.main(ActivityThread.java:8762)
    	at java.lang.reflect.Method.invoke(Native Method)
    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:604)
    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
    	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [androidx.compose.runtime.PausableMonotonicFrameClock@e59a2c4, androidx.compose.ui.platform.MotionDurationScaleImpl@35a35ad, StandaloneCoroutine{Cancelling}@a91c0e2, AndroidUiDispatcher@9a02c73]

```